### PR TITLE
feat: set `GIT_TERMINAL_PROMPT=0`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ RUN cp -r ./bin/updater ./workdir
 
 WORKDIR /app/workdir
 
+RUN git config --global http.postBuffer 157286400
+
 CMD ["./updater"]

--- a/internal/git/BundleRemote.go
+++ b/internal/git/BundleRemote.go
@@ -20,6 +20,7 @@ func BundleRemote(r data.Repository, h data.Host) (string, []string, error) {
 
 	// Create a bunde file
 	bundleCmd := exec.Command("git", "bundle", "create", fmt.Sprintf("%d.bundle", r.ID), "HEAD")
+	bundleCmd.Env = append(bundleCmd.Env, "GIT_TERMINAL_PROMPT=0")
 	bundleCmd.Dir = fmt.Sprintf("./%s", r.Name)
 
 	if err := bundleCmd.Run(); err != nil {

--- a/internal/git/GetLastCommit.go
+++ b/internal/git/GetLastCommit.go
@@ -11,6 +11,7 @@ import (
 func GetLastCommit(r data.Repository, h data.Host) (string, error) {
 	url := fmt.Sprintf("%s%s/%s.git", h.Prefix, r.Owner, r.Name)
 	lsRemoteCmd := exec.Command("git", "ls-remote", url, "HEAD")
+	lsRemoteCmd.Env = append(lsRemoteCmd.Env, "GIT_TERMINAL_PROMPT=0")
 
 	out, err := lsRemoteCmd.Output()
 


### PR DESCRIPTION
This commit sets `GIT_TERMINAL_PROMPT=0` during git commands. It not only resolves the issue of unnecessary login prompts when GitLab encounters a non-existent repository but also acts as a preemptive solution to potential future bugs. By bypassing the login prompt, it mitigates the risk of authentication-related errors not only with GitLab but also with other potential bugs that may arise from similar authentication mechanisms. This proactive approach ensures smoother command execution and reduces the likelihood of encountering authentication issues across various scenarios.

(Yes, this is the first pr for gitlab support!).